### PR TITLE
Finish adding some tests post migration

### DIFF
--- a/src/esgf_stac_tests/fixtures/default/conftest.py
+++ b/src/esgf_stac_tests/fixtures/default/conftest.py
@@ -87,3 +87,9 @@ def expected_result_count() -> int:
     """Get the expected result count for the current filter search scenario."""
     # Outside of specfic data challenges, we only care that SOME results were returned
     return NonZero()
+
+
+@pytest.fixture
+def supported_collections() -> list[str]:
+    """Return the collections that should be supported."""
+    return ["CMIP6"]

--- a/src/esgf_stac_tests/tests/test_stac.py
+++ b/src/esgf_stac_tests/tests/test_stac.py
@@ -145,3 +145,49 @@ def test_cmip6_collection_geospatial_extent(endpoint_url: str) -> None:
     assert "temporal" in cmip6_coll_extent
     assert "bbox" in cmip6_coll_extent["spatial"]
     assert "interval" in cmip6_coll_extent["temporal"]
+
+
+def test_cmip6_temporal_by_datetime(endpoint_url: str) -> None:
+    """Can we get results using the datetime keyword.
+
+    Note
+    ----
+    According to
+    https://pystac-client.readthedocs.io/en/latest/api.html#item-search this
+    should work.
+    """
+    client = pystac_client.Client.open(endpoint_url)
+    item_search = client.search(
+        collections=["CMIP6"],
+        datetime="1850-01-01/2015-01-01",
+        max_items=1,
+    )
+    item = next(item_search.items())
+    assert item
+
+
+def test_cmip6_temporal_by_query(endpoint_url: str) -> None:
+    """Can we get results using a query (not recommended)."""
+    client = pystac_client.Client.open(endpoint_url)
+    item_search = client.search(
+        collections=["CMIP6"],
+        query=["start_datetime>=1850-01-01", "end_datetime<=2015-01-01"],
+        max_items=1,
+    )
+    item = next(item_search.items())
+    assert item
+
+
+def test_cmip6_temporal_by_filter(endpoint_url: str) -> None:
+    """Can we filter results using t_intersects."""
+    client = pystac_client.Client.open(endpoint_url)
+    item_search = client.search(
+        collections=["CMIP6"],
+        filter={
+            "op": "t_intersects",
+            "args": [{"property": "datetime"}, "1850-01-01/2015-01-01"],
+        },
+        max_items=1,
+    )
+    item = next(item_search.items())
+    assert item

--- a/src/esgf_stac_tests/tests/test_stac.py
+++ b/src/esgf_stac_tests/tests/test_stac.py
@@ -49,11 +49,13 @@ def test_pagination(endpoint_url: str) -> None:
     assert actual_pages == expected_pages
 
 
+@pytest.mark.xfail(reason="CMIP6 STAC extension used is not public")
 def test_validate_catalog(endpoint_url: str) -> None:
     """Validate the STAC catalog for the endpoint against the STAC spec."""
     pystac_client.Client.open(endpoint_url).validate_all()
 
 
+@pytest.mark.xfail(reason="Temporary design decision")
 @pytest.mark.data_challenge_xfail(4, reason="Temporary design decision")
 def test_endpoint_uses_published_cmip6_extension(endpoint_url: str) -> None:
     """


### PR DESCRIPTION
Some of these are ugly, but I need to get it down what isn't working. Here is a summary:

- It appears that when we try to load pystac objects, we frequently see a `href` error but if we simply use the `XXX_as_dicts()` variant, things work well.
- Temporal queries are not working well. It could be poor publishing. I see a `datetime` in the properties which is `None` and then `start_datetime` and `end_datetime` which sometimes have bonkers values (like 8000-01-01).
- I added the facet counts test that Rhys showed us but I am sure there is a more canonical way to do it.